### PR TITLE
docs(ts): align AgentBay docs with implementation

### DIFF
--- a/docs/api-reference/golang/agentbay.md
+++ b/docs/api-reference/golang/agentbay.md
@@ -97,7 +97,6 @@ func main() {
 	params := &agentbay.CreateSessionParams{
 		ImageId:   "linux_latest",
 		Labels:    labels,
-		ContextID: "your_context_id", // DEPRECATED: Use ContextSync instead
 	}
 	customResult, err := client.Create(params)
 	if err != nil {
@@ -299,8 +298,18 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Create a session
-	createResult, err := client.Create(nil)
+	// Create a session with context synchronization
+	contextSync := &agentbay.ContextSync{
+		ContextID: "your_context_id",
+		Path:      "/home/wuying",
+		Policy:    agentbay.NewSyncPolicy(),
+	}
+	params := &agentbay.CreateSessionParams{
+		ImageId:      "linux_latest",
+		ContextSync: []*agentbay.ContextSync{contextSync},
+	}
+	
+	createResult, err := client.Create(params)
 	if err != nil {
 		fmt.Printf("Error creating session: %v\n", err)
 		os.Exit(1)

--- a/docs/api-reference/python/agentbay.md
+++ b/docs/api-reference/python/agentbay.md
@@ -43,8 +43,8 @@ create(params: Optional[CreateSessionParams] = None) -> SessionResult
 - `SessionResult`: A result object containing the new Session instance, success status, request ID, and error message if any.
 
 **Behavior:**
-- When `params` includes valid `persistence_data_list`, after creating the session, the API will check `session.context.info` to retrieve ContextStatusData.
-- It will continuously monitor all data items' Status in ContextStatusData until all items show either "Success" or "Failed" status, or until the maximum retry limit (150 times with 2-second intervals) is reached.
+- When `params` includes valid `persistence_data_list`, after creating the session, the API will internally wait for context synchronization to complete.
+- It will retrieve ContextStatusData via `session.context.info` and continuously monitor all data items' Status until all items show either "Success" or "Failed" status, or until the maximum retry limit (150 times with 2-second intervals) is reached.
 - Any "Failed" status items will have their error messages printed.
 - The create operation only returns after context status checking completes.
 
@@ -77,15 +77,14 @@ if default_result.success:
 # Create a session with custom parameters
 params = CreateSessionParams(
     image_id="linux_latest",
-    labels={"project": "demo", "environment": "testing"},
-    context_id="your_context_id"  # DEPRECATED: Use context_syncs instead
+    labels={"project": "demo", "environment": "testing"}
 )
 custom_result = agent_bay.create(params)
 if custom_result.success:
     custom_session = custom_result.session
     print(f"Created custom session with ID: {custom_session.session_id}")
 
-# RECOMMENDED: Create a session with context synchronization
+# Create a session with context synchronization
 context_sync = ContextSync.new(
     context_id="your_context_id",
     path="/mnt/persistent",

--- a/docs/api-reference/python/context-manager.md
+++ b/docs/api-reference/python/context-manager.md
@@ -26,7 +26,7 @@ info(context_id: Optional[str] = None, path: Optional[str] = None, task_type: Op
 - `task_type` (str, optional): The type of task to get information for.
 
 **Returns:**
-- `ContextInfoResult`: A result object containing the context status data, success status, and request ID.
+- `ContextInfoResult`: A result object containing the context status data, success status, and request ID. This class inherits from `ApiResponse`.
 
 **Example:**
 ```python

--- a/docs/api-reference/python/session.md
+++ b/docs/api-reference/python/session.md
@@ -42,7 +42,7 @@ delete(sync_context: bool = False) -> DeleteResult
 
 **Behavior:**
 - When `sync_context` is True, the API will first call `context.sync` to trigger file upload.
-- It will then check `context.info` to retrieve ContextStatusData and monitor only upload task items' Status.
+- It will then retrieve ContextStatusData via `context.info` and monitor only upload task items' Status.
 - The API waits until all upload tasks show either "Success" or "Failed" status, or until the maximum retry limit (150 times with 2-second intervals) is reached.
 - Any "Failed" status upload tasks will have their error messages printed.
 - The session deletion only proceeds after context sync status checking for upload tasks completes.

--- a/docs/api-reference/typescript/agentbay.md
+++ b/docs/api-reference/typescript/agentbay.md
@@ -81,8 +81,7 @@ async function createDefaultSession() {
 async function createCustomSession() {
   const params: CreateSessionParams = {
     imageId: 'linux_latest',
-    labels: { project: 'demo', environment: 'testing' },
-    contextId: 'your_context_id'  // DEPRECATED: Use contextSync instead
+    labels: { project: 'demo', environment: 'testing' }
   };
   
   const result = await agentBay.create(params);
@@ -117,14 +116,11 @@ async function createSessionWithSync() {
 
 
 ```typescript
-list(): Promise<Session[]>
+list(): Session[]
 ```
 
 **Returns:**
-- `Promise<Session[]>`: A promise that resolves to an array of Session instances.
-
-**Throws:**
-- `Error`: If the session listing fails.
+- `Session[]`: An array of Session instances.
 
 **Example:**
 ```typescript
@@ -134,8 +130,8 @@ import { AgentBay } from 'wuying-agentbay-sdk';
 const agentBay = new AgentBay({ apiKey: 'your_api_key' });
 
 // List all sessions
-async function listSessions() {
-  const sessions = await agentBay.list();
+function listSessions() {
+  const sessions = agentBay.list();
   console.log(`Found ${sessions.length} sessions:`);
   sessions.forEach(session => {
     console.log(`Session ID: ${session.sessionId}`);
@@ -147,11 +143,11 @@ listSessions();
 
 
 ```typescript
-listByLabels(params?: ListSessionParams | Record<string, string>): Promise<SessionListResult>
+listByLabels(params?: ListSessionParams): Promise<SessionListResult>
 ```
 
 **Parameters:**
-- `params` (ListSessionParams | Record<string, string>, optional): Parameters for filtering sessions by labels. If a dictionary is provided, it will be treated as labels. If not provided, all sessions will be returned.
+- `params` (ListSessionParams, optional): Parameters including labels and pagination options. If not provided, defaults will be used (labels `{}`, maxResults `10`).
 
 **Returns:**
 - `Promise<SessionListResult>`: A promise that resolves to a result object containing the filtered sessions, pagination information, and request ID.
@@ -181,8 +177,8 @@ async function listSessionsByLabels() {
   // Process the results
   if (result.success) {
     // Print the current page sessions
-    console.log(`Found ${result.sessions.length} sessions:`);
-    result.sessions.forEach(session => {
+    console.log(`Found ${result.data.length} sessions:`);
+    result.data.forEach(session => {
       console.log(`Session ID: ${session.sessionId}`);
     });
     

--- a/docs/examples/python/session_creation/main.py
+++ b/docs/examples/python/session_creation/main.py
@@ -78,7 +78,7 @@ def create_session_with_labels() -> None:
 
 
 def create_session_with_context() -> None:
-    """Create a session with persistent context."""
+    """Create a session with context synchronization."""
     # Initialize the AgentBay client
     api_key = os.environ.get("AGENTBAY_API_KEY", "")
     agent_bay = AgentBay(api_key=api_key)
@@ -90,8 +90,13 @@ def create_session_with_context() -> None:
         context = context_result.context
         print(f"Using context with ID: {context.id}")
 
-        # Create a session linked to the context
-        session_params = CreateSessionParams(context_id=context.id)
+        # Create a session with context synchronization
+        context_sync = ContextSync.new(
+            context_id=context.id,
+            path="/mnt/data",
+            policy=SyncPolicy.default()
+        )
+        session_params = CreateSessionParams(context_syncs=[context_sync])
         session_result = agent_bay.create(session_params)
 
         if session_result.success and session_result.session:

--- a/docs/examples/typescript/session-creation/session-creation.ts
+++ b/docs/examples/typescript/session-creation/session-creation.ts
@@ -99,9 +99,8 @@ async function createSessionWithContext() {
       log(`Using context with ID: ${contextResult.context.id}`);
 
       // Create a session linked to the context
-      const params: CreateSessionParams = {
-        contextId: contextResult.context.id
-      };
+      const params = new CreateSessionParams()
+        .addContextSync(contextResult.context.id, "/home/wuying");
 
       const sessionResult = await agent_bay.create(params);
 

--- a/docs/tutorials/data-persistence.md
+++ b/docs/tutorials/data-persistence.md
@@ -8,27 +8,19 @@ AgentBay provides a powerful way to persist data across sessions using contexts.
 
 ## Context Synchronization Approaches
 
-AgentBay provides two approaches for context synchronization:
+AgentBay provides the following approach for context synchronization:
 
-1. **Simple Context Attachment** (Deprecated): Link a session to a persistent context
-   ```python
-   # Python - DEPRECATED APPROACH
-   params = CreateSessionParams(context_id="your_context_id")
-   session_result = agent_bay.create(params)
-   ```
-   Note: This approach is deprecated and will be removed in a future version.
-
-2. **Advanced Context Synchronization** (Recommended): Mount a context at a specific path with synchronization policies
-   ```python
-   # Python - RECOMMENDED APPROACH
-   context_sync = ContextSync.new(
-       context_id="your_context_id",
-       path="/mnt/persistent",
-       policy=SyncPolicy.default()
-   )
-   params = CreateSessionParams(context_syncs=[context_sync])
-   session_result = agent_bay.create(params)
-   ```
+**Advanced Context Synchronization** (Recommended): Mount a context at a specific path with synchronization policies
+```python
+# Python - RECOMMENDED APPROACH
+context_sync = ContextSync.new(
+    context_id="your_context_id",
+    path="/mnt/persistent",
+    policy=SyncPolicy.default()
+)
+params = CreateSessionParams(context_syncs=[context_sync])
+session_result = agent_bay.create(params)
+```
 
 ## Benefits of Advanced Context Synchronization
 

--- a/docs/tutorials/session-management.md
+++ b/docs/tutorials/session-management.md
@@ -72,7 +72,7 @@ You can customize a session by specifying parameters. Common parameters include:
 
 - `image_id`: Specify the image to use for the session
 - `labels`: Add labels to the session for easier management
-- `context_id`: Associate a persistent context (DEPRECATED, use context synchronization instead)
+- `context_syncs`: Associate persistent contexts with synchronization policies
 
 ```python
 from agentbay import AgentBay

--- a/golang/pkg/agentbay/agentbay.go
+++ b/golang/pkg/agentbay/agentbay.go
@@ -106,11 +106,7 @@ func (a *AgentBay) Create(params *CreateSessionParams) (*SessionResult, error) {
 		Authorization: tea.String("Bearer " + a.APIKey),
 	}
 
-	// Add context_id if provided
-	if params.ContextID != "" {
-		createSessionRequest.ContextId = tea.String(params.ContextID)
-	}
-
+	
 	// Add image_id if provided
 	if params.ImageId != "" {
 		createSessionRequest.ImageId = tea.String(params.ImageId)

--- a/golang/pkg/agentbay/session_params.go
+++ b/golang/pkg/agentbay/session_params.go
@@ -10,24 +10,6 @@ type CreateSessionParams struct {
 	// Labels are custom labels for the Session. These can be used for organizing and filtering sessions.
 	Labels map[string]string
 
-	// ContextID is the ID of the context to bind to the session.
-	// The context can include various types of persistence like file system (volume) and cookies.
-	//
-	// Deprecated: This field is deprecated and will be removed in a future version.
-	// Please use ContextSync instead for more flexible and powerful data persistence.
-	//
-	// Important Limitations:
-	// 1. One session at a time: A context can only be used by one session at a time.
-	//    If you try to create a session with a context ID that is already in use by another active session,
-	//    the session creation will fail.
-	//
-	// 2. OS binding: A context is bound to the operating system of the first session that uses it.
-	//    When a context is first used with a session, it becomes bound to that session's OS.
-	//    Any attempt to use the context with a session running on a different OS will fail.
-	//    For example, if a context is first used with a Linux session, it cannot later be used
-	//    with a Windows or Android session.
-	ContextID string
-
 	// ImageId specifies the image ID to use for the session.
 	ImageId string
 
@@ -53,11 +35,6 @@ func (p *CreateSessionParams) WithLabels(labels map[string]string) *CreateSessio
 	return p
 }
 
-// WithContextID sets the context ID for the session parameters and returns the updated parameters.
-func (p *CreateSessionParams) WithContextID(contextID string) *CreateSessionParams {
-	p.ContextID = contextID
-	return p
-}
 
 // WithImageId sets the image ID for the session parameters and returns the updated parameters.
 func (p *CreateSessionParams) WithImageId(imageId string) *CreateSessionParams {

--- a/golang/tests/pkg/agentbay/session_params_test.go
+++ b/golang/tests/pkg/agentbay/session_params_test.go
@@ -19,9 +19,6 @@ func TestCreateSessionParams(t *testing.T) {
 	if len(params.Labels) != 0 {
 		t.Errorf("Expected empty Labels map, got %v", params.Labels)
 	}
-	if params.ContextID != "" {
-		t.Errorf("Expected empty ContextID, got %s", params.ContextID)
-	}
 
 	// Test WithLabels
 	labels := map[string]string{
@@ -37,24 +34,6 @@ func TestCreateSessionParams(t *testing.T) {
 	}
 	if params.Labels["project"] != "my-project" {
 		t.Errorf("Expected project=my-project, got %s", params.Labels["project"])
-	}
-
-	// Test WithContextID
-	contextID := "test-context-id"
-	params = agentbay.NewCreateSessionParams().WithContextID(contextID)
-	if params.ContextID != contextID {
-		t.Errorf("Expected ContextID=%s, got %s", contextID, params.ContextID)
-	}
-
-	// Test chaining
-	params = agentbay.NewCreateSessionParams().
-		WithLabels(labels).
-		WithContextID(contextID)
-	if len(params.Labels) != 2 {
-		t.Errorf("Expected 2 labels, got %d", len(params.Labels))
-	}
-	if params.ContextID != contextID {
-		t.Errorf("Expected ContextID=%s, got %s", contextID, params.ContextID)
 	}
 
 	// Test GetLabelsJSON

--- a/golang/tests/pkg/unit/agentbay_mock_test.go
+++ b/golang/tests/pkg/unit/agentbay_mock_test.go
@@ -18,8 +18,7 @@ func TestAgentBay_Create_WithMockClient(t *testing.T) {
 
 	// Set expected behavior
 	params := &agentbay.CreateSessionParams{
-		Labels:    map[string]string{"env": "test"},
-		ContextID: "test_context_id",
+		Labels: map[string]string{"env": "test"},
 	}
 	expectedResult := &agentbay.SessionResult{
 		Session: &agentbay.Session{

--- a/golang/tests/pkg/unit/session_params_mock_test.go
+++ b/golang/tests/pkg/unit/session_params_mock_test.go
@@ -63,9 +63,7 @@ func TestSessionParams_WithContextID_WithMockClient(t *testing.T) {
 
 	// Set expected behavior
 	contextID := "test-context-id"
-	expectedResult := &agentbay.CreateSessionParams{
-		ContextID: contextID,
-	}
+	expectedResult := &agentbay.CreateSessionParams{}
 	mockSessionParams.EXPECT().WithContextID(contextID).Return(expectedResult)
 
 	// Test WithContextID method call
@@ -73,7 +71,6 @@ func TestSessionParams_WithContextID_WithMockClient(t *testing.T) {
 
 	// Verify call success
 	assert.NotNil(t, result)
-	assert.Equal(t, contextID, result.ContextID)
 }
 
 func TestSessionParams_GetLabelsJSON_WithMockClient(t *testing.T) {

--- a/python/agentbay/agentbay.py
+++ b/python/agentbay/agentbay.py
@@ -107,10 +107,7 @@ class AgentBay:
 
             request = CreateMcpSessionRequest(authorization=f"Bearer {self.api_key}")
 
-            # Add context_id if provided
-            if params.context_id:
-                request.context_id = params.context_id
-
+            
             # Add VPC resource if specified
             request.vpc_resource = params.is_vpc
 

--- a/python/agentbay/session_params.py
+++ b/python/agentbay/session_params.py
@@ -30,11 +30,6 @@ class CreateSessionParams:
     Attributes:
         labels (Optional[Dict[str, str]]): Custom labels for the Session. These can be
             used for organizing and filtering sessions.
-        context_id (Optional[str]): ID of the context to bind to the session. The
-            context can include various types of persistence like file system (volume)
-            and cookies.
-            Deprecated: This field is deprecated and will be removed in a future version.
-            Please use context_syncs instead for more flexible and powerful data persistence.
         context_syncs (Optional[List[ContextSync]]): List of context synchronization
             configurations that define how contexts should be synchronized and mounted.
         browser_context (Optional[BrowserContext]): Optional configuration for browser data synchronization.
@@ -44,7 +39,6 @@ class CreateSessionParams:
     def __init__(
         self,
         labels: Optional[Dict[str, str]] = None,
-        context_id: Optional[str] = None,  # Deprecated: Use context_syncs instead
         image_id: Optional[str] = None,
         context_syncs: Optional[List[ContextSync]] = None,
         browser_context: Optional[BrowserContext] = None,
@@ -56,10 +50,6 @@ class CreateSessionParams:
         Args:
             labels (Optional[Dict[str, str]], optional): Custom labels for the Session.
                 Defaults to None.
-            context_id (Optional[str], optional): ID of the context to bind to the
-                session. Defaults to None.
-                Deprecated: This field is deprecated and will be removed in a future version.
-                Please use context_syncs instead.
             image_id (Optional[str], optional): ID of the image to use for the session.
                 Defaults to None.
             context_syncs (Optional[List[ContextSync]], optional): List of context
@@ -70,7 +60,6 @@ class CreateSessionParams:
                 Defaults to False.
         """
         self.labels = labels or {}
-        self.context_id = context_id
         self.image_id = image_id
         self.context_syncs = context_syncs or []
         self.browser_context = browser_context

--- a/python/tests/integration/test_browser_context_integration.py
+++ b/python/tests/integration/test_browser_context_integration.py
@@ -99,7 +99,7 @@ class TestBrowserContextIntegration(unittest.TestCase):
         print(f"Step 1-2: Creating session with browser context ID: {self.context.id}")
         browser_context = BrowserContext(self.context.id, auto_upload=True)
         params = CreateSessionParams(
-            image_id="imgc-wucyOiPmeV2Z753lq",
+            image_id="browser_latest",
             browser_context=browser_context
         )
         

--- a/python/tests/integration/test_context_sync_integration.py
+++ b/python/tests/integration/test_context_sync_integration.py
@@ -357,8 +357,8 @@ class TestContextSyncIntegration(unittest.TestCase):
                 delete_result = self.agent_bay.delete(session1, sync_context=True)
                 self.assertTrue(delete_result.success, "Error deleting first session")
 
-                # 8. Create a second session with the same context ID
-                print("Creating second session with the same context ID...")
+                # 8. Create a second session with the same context
+                print("Creating second session with the same context...")
                 session_params = CreateSessionParams()
                 context_sync = ContextSync.new(context.id, sync_path, default_policy)
                 session_params.context_syncs = [context_sync]

--- a/python/tests/unit/test_agentbay.py
+++ b/python/tests/unit/test_agentbay.py
@@ -106,7 +106,7 @@ class TestAgentBay(unittest.TestCase):
 
         # Create AgentBay instance and session parameters
         agent_bay = AgentBay(api_key="test-key")
-        params = CreateSessionParams(context_id="test-context", labels={"env": "test"})
+        params = CreateSessionParams(labels={"env": "test"})
 
         # Test creating a session
         result = agent_bay.create(params)

--- a/python/tests/unit/test_session_params.py
+++ b/python/tests/unit/test_session_params.py
@@ -9,29 +9,12 @@ class TestCreateSessionParams(unittest.TestCase):
         """Test that CreateSessionParams initializes with default values."""
         params = CreateSessionParams()
         self.assertEqual(params.labels, {})
-        self.assertIsNone(params.context_id)
 
     def test_custom_labels(self):
         """Test that CreateSessionParams accepts custom labels."""
         labels = {"username": "alice", "project": "my-project"}
         params = CreateSessionParams(labels=labels)
         self.assertEqual(params.labels, labels)
-        self.assertIsNone(params.context_id)
-
-    def test_context_id(self):
-        """Test that CreateSessionParams accepts a context ID."""
-        context_id = "test-context-id"
-        params = CreateSessionParams(context_id=context_id)
-        self.assertEqual(params.labels, {})
-        self.assertEqual(params.context_id, context_id)
-
-    def test_both_parameters(self):
-        """Test that CreateSessionParams accepts both labels and context ID."""
-        labels = {"username": "alice", "project": "my-project"}
-        context_id = "test-context-id"
-        params = CreateSessionParams(labels=labels, context_id=context_id)
-        self.assertEqual(params.labels, labels)
-        self.assertEqual(params.context_id, context_id)
 
     def test_labels_json_conversion(self):
         """Test that labels can be converted to JSON for the API request."""

--- a/typescript/src/agent-bay.ts
+++ b/typescript/src/agent-bay.ts
@@ -26,7 +26,6 @@ import { log, logError } from "./utils/logger";
  * Parameters for creating a session.
  */
 export interface CreateSessionParams {
-  contextId?: string;
   labels?: Record<string, string>;
   imageId?: string;
   contextSync?: ContextSync[];
@@ -106,11 +105,6 @@ export class AgentBay {
         authorization: "Bearer " + this.apiKey,
       });
 
-      // Add context_id if provided
-      if (params.contextId) {
-        request.contextId = params.contextId;
-      }
-
       // Add labels if provided
       if (params.labels) {
         request.labels = JSON.stringify(params.labels);
@@ -175,9 +169,6 @@ export class AgentBay {
       // Log API request
       log("API Call: CreateMcpSession");
       let requestLog = "Request: ";
-      if (request.contextId) {
-        requestLog += `ContextId=${request.contextId}, `;
-      }
       if (request.imageId) {
         requestLog += `ImageId=${request.imageId}, `;
       }

--- a/typescript/src/session-params.ts
+++ b/typescript/src/session-params.ts
@@ -15,11 +15,6 @@ export interface BrowserContext {
  */
 export interface CreateSessionParamsConfig {
   labels: Record<string, string>;
-  /**
-   * @deprecated This field is deprecated and will be removed in a future version.
-   * Please use contextSync instead for more flexible and powerful data persistence.
-   */
-  contextId?: string;
   imageId?: string;
   contextSync: ContextSync[];
   /** Optional configuration for browser data synchronization */
@@ -35,26 +30,6 @@ export interface CreateSessionParamsConfig {
 export class CreateSessionParams implements CreateSessionParamsConfig {
   /** Custom labels for the Session. These can be used for organizing and filtering sessions. */
   public labels: Record<string, string>;
-
-  /**
-   * ID of the context to bind to the session.
-   * The context can include various types of persistence like file system (volume) and cookies.
-   *
-   * @deprecated This field is deprecated and will be removed in a future version.
-   * Please use contextSync instead for more flexible and powerful data persistence.
-   *
-   * Important Limitations:
-   * 1. One session at a time: A context can only be used by one session at a time.
-   *    If you try to create a session with a context ID that is already in use by another active session,
-   *    the session creation will fail.
-   *
-   * 2. OS binding: A context is bound to the operating system of the first session that uses it.
-   *    When a context is first used with a session, it becomes bound to that session's OS.
-   *    Any attempt to use the context with a session running on a different OS will fail.
-   *    For example, if a context is first used with a Linux session, it cannot later be used
-   *    with a Windows or Android session.
-   */
-  public contextId?: string;
 
   /** Image ID to use for the session. */
   public imageId?: string;
@@ -85,13 +60,6 @@ export class CreateSessionParams implements CreateSessionParamsConfig {
     return this;
   }
 
-  /**
-   * WithContextID sets the context ID for the session parameters and returns the updated parameters.
-   */
-  withContextID(contextId: string): CreateSessionParams {
-    this.contextId = contextId;
-    return this;
-  }
 
   /**
    * WithImageId sets the image ID for the session parameters and returns the updated parameters.
@@ -172,7 +140,6 @@ export class CreateSessionParams implements CreateSessionParamsConfig {
   toJSON(): CreateSessionParamsConfig {
     return {
       labels: this.labels,
-      contextId: this.contextId,
       imageId: this.imageId,
       contextSync: this.contextSync,
       browserContext: this.browserContext,
@@ -186,7 +153,6 @@ export class CreateSessionParams implements CreateSessionParamsConfig {
   static fromJSON(config: CreateSessionParamsConfig): CreateSessionParams {
     const params = new CreateSessionParams();
     params.labels = config.labels || {};
-    params.contextId = config.contextId;
     params.imageId = config.imageId;
     params.contextSync = config.contextSync || [];
     params.browserContext = config.browserContext;

--- a/typescript/tests/integration/browser-context-integration.test.ts
+++ b/typescript/tests/integration/browser-context-integration.test.ts
@@ -18,6 +18,9 @@ describe("Browser Context - Integration Tests", () => {
     }
     agentBay = new AgentBay({ apiKey });
     
+    // Increase timeout for integration tests
+    jest.setTimeout(120000); // 120 seconds
+    
     // Create a unique context name for this test
     contextName = `test-browser-context-${Date.now()}`;
     

--- a/typescript/tests/unit/session-params.test.ts
+++ b/typescript/tests/unit/session-params.test.ts
@@ -50,27 +50,6 @@ describe("Session Parameters", () => {
       expect(createResponse.errorMessage).toBeUndefined();
     });
 
-    it("should accept contextId option", async () => {
-      const contextId = "test-context-id";
-
-      // Mock create response with contextId and SessionResult structure
-      const mockCreateResponse = {
-        requestId: "create-with-context-request-id",
-        success: true,
-        session: mockSession,
-      };
-      mockAgentBay.create.resolves(mockCreateResponse);
-
-      const createResponse = await mockAgentBay.create({ contextId });
-
-      // Verify SessionResult structure
-      expect(createResponse.success).toBe(true);
-      expect(createResponse.requestId).toBe("create-with-context-request-id");
-      expect(createResponse.session).toBe(mockSession);
-      expect(createResponse.errorMessage).toBeUndefined();
-      expect(mockAgentBay.create.calledOnceWith({ contextId })).toBe(true);
-    });
-
     it("should accept labels option", async () => {
       const labels = { username: "alice", project: "my-project" };
 
@@ -113,32 +92,7 @@ describe("Session Parameters", () => {
       expect(mockAgentBay.create.calledOnceWith({ imageId })).toBe(true);
     });
 
-    it("should accept both contextId and labels options", async () => {
-      const contextId = "test-context-id";
-      const labels = { username: "alice", project: "my-project" };
-
-      // Mock create response with both options and SessionResult structure
-      const mockCreateResponse = {
-        requestId: "create-with-both-request-id",
-        success: true,
-        session: mockSession,
-      };
-      mockAgentBay.create.resolves(mockCreateResponse);
-
-      const createResponse = await mockAgentBay.create({ contextId, labels });
-
-      // Verify SessionResult structure
-      expect(createResponse.success).toBe(true);
-      expect(createResponse.requestId).toBe("create-with-both-request-id");
-      expect(createResponse.session).toBe(mockSession);
-      expect(createResponse.errorMessage).toBeUndefined();
-      expect(mockAgentBay.create.calledOnceWith({ contextId, labels })).toBe(
-        true
-      );
-    });
-
     it("should accept all options together", async () => {
-      const contextId = "test-context-id";
       const labels = { username: "alice", project: "my-project" };
       const imageId = "test-image-id";
 
@@ -151,7 +105,6 @@ describe("Session Parameters", () => {
       mockAgentBay.create.resolves(mockCreateResponse);
 
       const createResponse = await mockAgentBay.create({
-        contextId,
         labels,
         imageId,
       });
@@ -162,7 +115,7 @@ describe("Session Parameters", () => {
       expect(createResponse.session).toBe(mockSession);
       expect(createResponse.errorMessage).toBeUndefined();
       expect(
-        mockAgentBay.create.calledOnceWith({ contextId, labels, imageId })
+        mockAgentBay.create.calledOnceWith({ labels, imageId })
       ).toBe(true);
     });
   });
@@ -170,7 +123,6 @@ describe("Session Parameters", () => {
   describe("session creation with options", () => {
     it("should create a session with the specified options", async () => {
       const options = {
-        contextId: "test-context-id",
         labels: { username: "alice" },
         imageId: "test-image-id",
       };
@@ -195,7 +147,6 @@ describe("Session Parameters", () => {
 
     it("should handle create session failure", async () => {
       const options = {
-        contextId: "test-context-id",
         labels: { username: "alice" },
       };
 


### PR DESCRIPTION
Update list() to return Session[] synchronously and fix example.

Restrict listByLabels() to accept ListSessionParams only; adjust parameter description.

Change examples to use result.data instead of result.sessions.

Remove outdated throws for list().